### PR TITLE
Implement buffer storage and add unit test

### DIFF
--- a/APIs/Src/data_logger.c
+++ b/APIs/Src/data_logger.c
@@ -142,8 +142,9 @@ bool data_logger_store_measurement(uint8_t sensor_id, ConcentracionesPM valores,
     // Almacenar en buffer de alta frecuencia
     buffer_circular_agregar(&buffer_alta_frecuencia, &nueva_medicion);
 
-    // Actualizar buffers de hora y día según corresponda
-    // (implementación pendiente)
+    // También almacenar en los buffers de hora y día
+    buffer_circular_agregar(&buffer_hora, &nueva_medicion);
+    buffer_circular_agregar(&buffer_dia, &nueva_medicion);
 
     return true;
 }
@@ -550,5 +551,11 @@ void build_iso8601_timestamp(char * buffer, size_t len, const ParticulateData * 
     snprintf(buffer, len, "%04u-%02u-%02uT%02u:%02u:%02uZ", data->year, data->month, data->day,
              data->hour, data->min, data->sec);
 }
+
+#ifdef UNIT_TEST
+BufferCircular *get_buffer_high_freq(void) { return &buffer_alta_frecuencia; }
+BufferCircular *get_buffer_hourly(void) { return &buffer_hora; }
+BufferCircular *get_buffer_daily(void) { return &buffer_dia; }
+#endif
 
 /* === End of documentation ==================================================================== */

--- a/Tests/data_logger_buffers_runner.c
+++ b/Tests/data_logger_buffers_runner.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include "stubs/ff.h"
+#include "stubs/fatfs.h"
+#include "stubs/fatfs_sd.h"
+#include "stubs/microSD.h"
+#include "stubs/microSD_utils.h"
+#include "stubs/rtc.h"
+#include "stubs/time_rtc.h"
+#include "stubs/uart.h"
+#include "stubs/rtc_ds3231_for_stm32_hal.h"
+#include "stubs/ParticulateDataAnalyzer.h"
+#include "stubs/mp_sensors_info.h"
+#include "stubs/main.h"
+#include "stubs/usart.h"
+
+#define UNIT_TEST
+#include "../APIs/Src/data_logger.c"
+
+BufferCircular *get_buffer_high_freq(void);
+BufferCircular *get_buffer_hourly(void);
+BufferCircular *get_buffer_daily(void);
+
+int main(void){
+    ConcentracionesPM val = {1.0f, 2.0f, 3.0f, 4.0f};
+    if(!data_logger_store_measurement(2, val, 25.0f, 50.0f)) return 1;
+    BufferCircular *hf = get_buffer_high_freq();
+    BufferCircular *h = get_buffer_hourly();
+    BufferCircular *d = get_buffer_daily();
+    if(hf->cantidad==1 && h->cantidad==1 && d->cantidad==1 &&
+       hf->datos[0].sensor_id==2 && h->datos[0].sensor_id==2 && d->datos[0].sensor_id==2){
+        printf("PASS\n");
+        return 0;
+    }else{
+        printf("FAIL\n");
+        return 1;
+    }
+}

--- a/Tests/stubs/ParticulateDataAnalyzer.h
+++ b/Tests/stubs/ParticulateDataAnalyzer.h
@@ -1,0 +1,21 @@
+#ifndef PARTICULATEDATAANALYZER_H
+#define PARTICULATEDATAANALYZER_H
+#include <stdint.h>
+typedef struct {
+    uint8_t sensor_id;
+    float pm1_0;
+    float pm2_5;
+    float pm4_0;
+    float pm10;
+    float temp_amb;
+    float hum_amb;
+    float temp_cam;
+    float hum_cam;
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t min;
+    uint8_t sec;
+} ParticulateData;
+#endif

--- a/Tests/stubs/fatfs.h
+++ b/Tests/stubs/fatfs.h
@@ -1,0 +1,4 @@
+#ifndef FATFS_H
+#define FATFS_H
+#include "ff.h"
+#endif

--- a/Tests/stubs/fatfs_sd.h
+++ b/Tests/stubs/fatfs_sd.h
@@ -1,0 +1,3 @@
+#ifndef FATFS_SD_H
+#define FATFS_SD_H
+#endif

--- a/Tests/stubs/fatfs_stub.c
+++ b/Tests/stubs/fatfs_stub.c
@@ -1,0 +1,10 @@
+#include "ff.h"
+FRESULT f_mount(FATFS* fs, const char* path, unsigned char opt){return FR_OK;}
+FRESULT f_open(FIL* fp, const char* path, unsigned char mode){return FR_OK;}
+FRESULT f_write(FIL* fp, const void* buff, unsigned int btw, UINT* bw){ if(bw) *bw = btw; return FR_OK;}
+FRESULT f_sync(FIL* fp){return FR_OK;}
+FRESULT f_close(FIL* fp){return FR_OK;}
+unsigned int f_size(FIL* fp){return 0;}
+FRESULT f_mkdir(const char* path){return FR_OK;}
+FRESULT f_stat(const char* path, void* fno){return FR_OK;}
+FRESULT f_lseek(FIL* fp, unsigned int ofs){return FR_OK;}

--- a/Tests/stubs/ff.h
+++ b/Tests/stubs/ff.h
@@ -1,0 +1,27 @@
+#ifndef FF_H
+#define FF_H
+typedef int FRESULT;
+typedef int FIL;
+typedef int FATFS;
+typedef unsigned int DWORD;
+typedef unsigned int UINT;
+#define FR_OK 0
+#define FR_DISK_ERR 1
+#define FR_INT_ERR 2
+#define FR_NOT_READY 3
+#define FR_NO_FILE 4
+#define FR_NO_PATH 5
+#define FR_INVALID_NAME 6
+#define FR_DENIED 7
+#define FR_EXIST 8
+#define FR_INVALID_OBJECT 9
+#define FR_WRITE_PROTECTED 10
+#define FR_INVALID_DRIVE 11
+#define FR_NOT_ENABLED 12
+#define FR_NO_FILESYSTEM 13
+#define FR_TIMEOUT 14
+#define FR_LOCKED 15
+#define FA_OPEN_APPEND 0x30
+#define FA_WRITE 0x02
+#define FA_OPEN_ALWAYS 0x10
+#endif

--- a/Tests/stubs/main.h
+++ b/Tests/stubs/main.h
@@ -1,0 +1,3 @@
+#ifndef MAIN_H
+#define MAIN_H
+#endif

--- a/Tests/stubs/microSD.h
+++ b/Tests/stubs/microSD.h
@@ -1,0 +1,5 @@
+#ifndef MICROSD_H
+#define MICROSD_H
+#include "ff.h"
+typedef struct {int dummy;} MicroSD;
+#endif

--- a/Tests/stubs/microSD_utils.c
+++ b/Tests/stubs/microSD_utils.c
@@ -1,0 +1,3 @@
+#include "microSD_utils.h"
+#include <stdbool.h>
+bool microSD_appendLineAbsolute(const char *filepath, const char *line){return true;}

--- a/Tests/stubs/microSD_utils.h
+++ b/Tests/stubs/microSD_utils.h
@@ -1,0 +1,5 @@
+#ifndef MICROSD_UTILS_H
+#define MICROSD_UTILS_H
+#include <stdbool.h>
+bool microSD_appendLineAbsolute(const char *filepath, const char *line);
+#endif

--- a/Tests/stubs/mp_sensors_info.h
+++ b/Tests/stubs/mp_sensors_info.h
@@ -1,0 +1,6 @@
+#ifndef MP_SENSORS_INFO_H
+#define MP_SENSORS_INFO_H
+#define LOCATION_COORDS "0,0"
+typedef struct {char serial_number[1]; char location_name[1];} MP_SensorInfo;
+static MP_SensorInfo sensor_metadata[1];
+#endif

--- a/Tests/stubs/rtc.h
+++ b/Tests/stubs/rtc.h
@@ -1,0 +1,4 @@
+#ifndef RTC_H
+#define RTC_H
+typedef struct {} RTC_HandleTypeDef;
+#endif

--- a/Tests/stubs/rtc_ds3231_for_stm32_hal.h
+++ b/Tests/stubs/rtc_ds3231_for_stm32_hal.h
@@ -1,0 +1,5 @@
+#ifndef RTC_DS3231_FOR_STM32_HAL_H_
+#define RTC_DS3231_FOR_STM32_HAL_H_
+#include <stdint.h>
+typedef struct {uint8_t seconds;uint8_t minutes;uint8_t hours;uint8_t day;uint8_t month;uint16_t year;} DS3231_DateTime;
+#endif

--- a/Tests/stubs/time_rtc.c
+++ b/Tests/stubs/time_rtc.c
@@ -1,0 +1,12 @@
+#include "time_rtc.h"
+#include <string.h>
+void time_rtc_GetFormattedDateTime(char *buffer, size_t len){
+    const char *fixed = "2025-06-16 12:00:00";
+    strncpy(buffer, fixed, len);
+    if(len>0) buffer[len-1]='\0';
+}
+bool ds3231_get_datetime(ds3231_time_t* dt){
+    if(!dt) return false;
+    dt->year=2025; dt->month=6; dt->day=16; dt->hour=12; dt->min=0; dt->sec=0;
+    return true;
+}

--- a/Tests/stubs/time_rtc.h
+++ b/Tests/stubs/time_rtc.h
@@ -1,0 +1,8 @@
+#ifndef TIME_RTC_H
+#define TIME_RTC_H
+#include <stddef.h>
+#include <stdbool.h>
+typedef struct {unsigned char hour; unsigned char min; unsigned char sec; unsigned char day; unsigned char month; unsigned short year;} ds3231_time_t;
+void time_rtc_GetFormattedDateTime(char *buffer, size_t len);
+bool ds3231_get_datetime(ds3231_time_t* dt);
+#endif

--- a/Tests/stubs/uart.h
+++ b/Tests/stubs/uart.h
@@ -1,0 +1,7 @@
+#ifndef UART_H
+#define UART_H
+#include <stdio.h>
+static inline void uart_print(const char *format, ...) {
+    (void)format;
+}
+#endif

--- a/Tests/stubs/usart.h
+++ b/Tests/stubs/usart.h
@@ -1,0 +1,4 @@
+#ifndef USART_H
+#define USART_H
+typedef struct {} UART_HandleTypeDef;
+#endif

--- a/Tests/test_data_logger_buffers.py
+++ b/Tests/test_data_logger_buffers.py
@@ -1,0 +1,17 @@
+import subprocess, os, sys
+
+def build_and_run():
+    compile_cmd = [
+        'gcc', '-I', 'Tests/stubs', '-I', 'APIs/Inc', '-I', 'APIs/Config',
+        'Tests/data_logger_buffers_runner.c',
+        'Tests/stubs/time_rtc.c', 'Tests/stubs/microSD_utils.c',
+        'Tests/stubs/fatfs_stub.c', '-o', 'Tests/data_logger_buffers_runner'
+    ]
+    subprocess.check_call(compile_cmd)
+    result = subprocess.run(['Tests/data_logger_buffers_runner'], capture_output=True, text=True)
+    return result
+
+def test_store_measurement():
+    result = build_and_run()
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert 'PASS' in result.stdout


### PR DESCRIPTION
## Summary
- complete `data_logger_store_measurement` by updating hourly and daily buffers
- expose buffers for testing when `UNIT_TEST` is defined
- add C test harness and python test
- provide stub headers and implementations to compile tests

## Testing
- `pytest -q Tests/test_data_logger_buffers.py`

------
https://chatgpt.com/codex/tasks/task_e_68505b4c407c832db6ffdb96ab170087