### PR TITLE
Refactor proceso observador

### DIFF
--- a/APIs/Inc/data_logger.h
+++ b/APIs/Inc/data_logger.h
@@ -31,7 +31,11 @@
 /* === Headers files inclusions
  * ================================================================ */
 
+#ifdef UNIT_TESTING
+#include "ff_stub.h"
+#else
 #include "ff.h"
+#endif
 #include "shdlc.h" // Para acceder a ConcentracionesPM
 #include "uart.h"
 #include <stdbool.h>
@@ -51,10 +55,10 @@ extern "C" {
 
 // Tamaños de los buffers circulares
 #define BUFFER_HIGH_FREQ_SIZE 60 // 60 muestras cada 10min = 10h
-#define BUFFER_HOURLY_SIZE    24 // 24 muestras = 1 día
-#define BUFFER_DAILY_SIZE     30 // 30 muestras = 1 mes
+#define BUFFER_HOURLY_SIZE 24    // 24 muestras = 1 día
+#define BUFFER_DAILY_SIZE 30     // 30 muestras = 1 mes
 
-#define CSV_LINE_BUFFER_SIZE  128
+#define CSV_LINE_BUFFER_SIZE 128
 
 /* === Public data type declarations
  * =========================================================== */
@@ -70,28 +74,28 @@ extern "C" {
  * @param hum    Promedio de humedad relativa en %
  * @return FRESULT Código de resultado de la operación FatFs
  */
-FRESULT guardar_promedio_csv(float pm1_0, float pm2_5, float pm4_0, float pm10, float temp,
-                             float hum);
+FRESULT guardar_promedio_csv(float pm1_0, float pm2_5, float pm4_0, float pm10,
+                             float temp, float hum);
 
 /**
  * @brief Estructura para almacenar una medición de material particulado
  */
 typedef struct {
-    char timestamp[32];        // Formato ISO8601
-    uint8_t sensor_id;         // ID del sensor
-    ConcentracionesPM valores; // Valores de concentración
-    float temperatura;         // Temperatura ambiente (opcional)
-    float humedad;             // Humedad ambiente (opcional)
+  char timestamp[32];        // Formato ISO8601
+  uint8_t sensor_id;         // ID del sensor
+  ConcentracionesPM valores; // Valores de concentración
+  float temperatura;         // Temperatura ambiente (opcional)
+  float humedad;             // Humedad ambiente (opcional)
 } MedicionMP;
 
 /**
  * @brief Estructura para un buffer circular de datos
  */
 typedef struct {
-    MedicionMP * datos; // Array de mediciones
-    uint32_t capacidad; // Tamaño máximo del buffer
-    uint32_t inicio;    // Índice del elemento más antiguo
-    uint32_t cantidad;  // Cantidad actual de elementos
+  MedicionMP *datos;  // Array de mediciones
+  uint32_t capacidad; // Tamaño máximo del buffer
+  uint32_t inicio;    // Índice del elemento más antiguo
+  uint32_t cantidad;  // Cantidad actual de elementos
 } BufferCircular;
 
 /* === Public variable declarations
@@ -117,8 +121,8 @@ bool data_logger_init(void);
  * @param humedad Humedad ambiente (opcional, usar -999 si no disponible)
  * @return true si el almacenamiento fue exitoso
  */
-bool data_logger_store_measurement(uint8_t sensor_id, ConcentracionesPM valores, float temperatura,
-                                   float humedad);
+bool data_logger_store_measurement(uint8_t sensor_id, ConcentracionesPM valores,
+                                   float temperatura, float humedad);
 
 /**
  * @brief Obtiene el promedio de PM2.5 de las últimas N mediciones
@@ -144,24 +148,25 @@ void data_logger_print_summary(void);
  * @param max_len Tamaño máximo del búfer de salida
  * @return true si el formateo fue exitoso, false si hubo error de espacio
  */
-bool format_csv_line(const ParticulateData * data, char * csv_line, size_t max_len);
+bool format_csv_line(const ParticulateData *data, char *csv_line,
+                     size_t max_len);
 
-bool build_csv_filepath_from_datetime(char * filepath, size_t max_len);
+bool build_csv_filepath_from_datetime(char *filepath, size_t max_len);
 
-bool log_data_to_sd(const ParticulateData * data);
+bool log_data_to_sd(const ParticulateData *data);
 
 void print_fatfs_error(FRESULT res);
 
-bool data_logger_write_csv_line(const ParticulateData * data);
+bool data_logger_write_csv_line(const ParticulateData *data);
 
-bool data_logger_store_raw(const ParticulateData * data);
+bool data_logger_store_raw(const ParticulateData *data);
 
-bool crear_directorio_fecha(const ds3231_time_t * dt);
+bool crear_directorio_fecha(const ds3231_time_t *dt);
 
-bool escribir_linea_csv(const char * filepath, const char * linea);
+bool escribir_linea_csv(const char *filepath, const char *linea);
 
-bool obtener_ruta_archivo(const ds3231_time_t * dt, const char * nombre_archivo, char * filepath,
-                          size_t len);
+bool obtener_ruta_archivo(const ds3231_time_t *dt, const char *nombre_archivo,
+                          char *filepath, size_t len);
 
 /* === End of documentation
  * ==================================================================== */

--- a/Tests/stubs/fatfs.h
+++ b/Tests/stubs/fatfs.h
@@ -2,6 +2,6 @@
 #ifdef UNIT_TESTING
 #ifndef FATFS_H
 #define FATFS_H
-#include "stubs/fatfs_stub.h"
+#include "fatfs_stub.h"
 #endif
 #endif

--- a/Tests/stubs/microSD.h
+++ b/Tests/stubs/microSD.h
@@ -1,9 +1,9 @@
 #ifdef UNIT_TESTING
 #ifndef MICROSD_H
 #define MICROSD_H
-#include "ff.h"
+#include "ff_stub.h"
 typedef struct {
-    int dummy;
+  int dummy;
 } MicroSD;
 #endif
 #endif


### PR DESCRIPTION
## Summary
- refactor common code of `proceso_observador_with_time` and `proceso_observador_3PM_2TH`
- introduce internal `proceso_observador_base`
- update stubs and data logger header for unit testing

## Testing
- `pre-commit run --files APIs/Src/proceso_observador.c APIs/Inc/data_logger.h Tests/stubs/fatfs.h Tests/stubs/microSD.h APIs/Inc/proceso_observador.h`
- `pytest -q` *(fails: ff.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a472ab08832dad135ce5f768369d