### PR TITLE
Add RTC-synced averaging windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ graph TD
 | **💾 MicroSD + FatFS** | ✅ Completo | FAT32, estructura `/YYYY/MM/DD/`, sincronización |
 | **📊 Proceso Observador** | ✅ Completo | Muestreo c/1min, validación, reintentos × 3 |
 | **📈 Análisis Estadístico** | ✅ Completo | Media, máx/mín, desviación, validación |
-| **🗃️ Data Logger** | ✅ Completo | Buffers circulares, CSV temporal, error handling |
+| **🗃️ Data Logger** | ✅ Completo | Buffers circulares, CSV temporal, promedios sincronizados al RTC |
 | **🕰️ Gestión de Tiempo** | ✅ Completo | Unificación RTC, timestamps ISO8601 |
 | **📱 Debug UART** | ✅ Completo | Terminal serie, logs detallados |
 | **🌐 WiFi ESP8266** | 🔄 En desarrollo | Buffer reintentos, protocolo HTTP |
@@ -292,6 +292,12 @@ cd Tesis_SPS30
 2025-06-16T00:02:58Z,1,3.6,4.0,4.3,4.4,15.0,58.2,16.1,91.8
 2025-06-16T00:03:25Z,1,2.0,2.3,2.5,2.5,15.0,58.2,16.1,91.9
 2025-06-16T00:03:52Z,1,3.3,3.5,3.5,3.5,15.0,58.4,16.1,91.9
+```
+
+Ejemplo de promedio sincronizado por tiempo:
+```csv
+timestamp,type,pm2_5_avg,sample_count,pm2_5_min,pm2_5_max,pm2_5_std
+2025-06-16 12:10:00,avg10,10.0,60,10.0,10.0,0.0
 ```
 
 **Características del formato CSV implementado:**

--- a/Tests/data_logger_time_runner.c
+++ b/Tests/data_logger_time_runner.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#define UNIT_TESTING
+#include "stubs/fatfs_stub.h"
+#include "stubs/ff_stub.h"
+#include "stubs/fatfs.h"
+#include "stubs/fatfs_sd.h"
+#include "stubs/microSD_stub.h"
+#include "stubs/microSD_utils.h"
+#include "stubs/rtc.h"
+#include "stubs/time_rtc.h"
+#include "stubs/uart.h"
+#include "stubs/rtc_ds3231_for_stm32_hal.h"
+#include "stubs/ParticulateDataAnalyzer.h"
+#include "stubs/mp_sensors_info.h"
+#include "stubs/main.h"
+#include "stubs/usart.h"
+#include "../APIs/Src/data_logger.c"
+
+int main(void){
+    stub_set_time(12,0,0);
+    for(int i=0;i<60;i++){
+        stub_advance_seconds(10);
+        proceso_analisis_periodico(10.0f); // constant value
+    }
+    float *hbuf = get_avg1h_buffer();
+    if(get_hourly_index()>0){
+        for(int i=1;i<6;i++){
+            for(int j=0;j<60;j++){ stub_advance_seconds(10); proceso_analisis_periodico(10.0f); }
+        }
+        if(get_daily_index()>0){ printf("PASS\n"); return 0; }
+    }
+    printf("hourly_index=%d daily_index=%d first=%f\n", get_hourly_index(), get_daily_index(), hbuf[0]);
+    printf("FAIL\n");
+    return 1;
+}
+
+// debugging

--- a/Tests/stubs/time_rtc.c
+++ b/Tests/stubs/time_rtc.c
@@ -1,12 +1,26 @@
 #include "time_rtc.h"
 #include <string.h>
+static ds3231_time_t current_time = {12,0,0,16,6,2025};
+
 void time_rtc_GetFormattedDateTime(char *buffer, size_t len){
-    const char *fixed = "2025-06-16 12:00:00";
-    strncpy(buffer, fixed, len);
+    snprintf(buffer, len, "%04d-%02d-%02d %02d:%02d:%02d", current_time.year, current_time.month,
+             current_time.day, current_time.hour, current_time.min, current_time.sec);
     if(len>0) buffer[len-1]='\0';
 }
+
 bool ds3231_get_datetime(ds3231_time_t* dt){
     if(!dt) return false;
-    dt->year=2025; dt->month=6; dt->day=16; dt->hour=12; dt->min=0; dt->sec=0;
+    *dt = current_time;
     return true;
+}
+
+void stub_set_time(unsigned char hour, unsigned char min, unsigned char sec){
+    current_time.hour = hour; current_time.min = min; current_time.sec = sec;
+}
+
+void stub_advance_seconds(unsigned int s){
+    current_time.sec += s;
+    while(current_time.sec >= 60){ current_time.sec -= 60; current_time.min++; }
+    while(current_time.min >= 60){ current_time.min -= 60; current_time.hour++; }
+    while(current_time.hour >= 24){ current_time.hour -= 24; }
 }

--- a/Tests/stubs/time_rtc.h
+++ b/Tests/stubs/time_rtc.h
@@ -5,4 +5,6 @@
 typedef struct {unsigned char hour; unsigned char min; unsigned char sec; unsigned char day; unsigned char month; unsigned short year;} ds3231_time_t;
 void time_rtc_GetFormattedDateTime(char *buffer, size_t len);
 bool ds3231_get_datetime(ds3231_time_t* dt);
+void stub_set_time(unsigned char hour, unsigned char min, unsigned char sec);
+void stub_advance_seconds(unsigned int s);
 #endif

--- a/Tests/test_time_windows.py
+++ b/Tests/test_time_windows.py
@@ -1,0 +1,14 @@
+import subprocess
+
+def build_and_run():
+    compile_cmd = [
+        'gcc','-I','Tests/stubs','-I','APIs/Inc','Tests/data_logger_time_runner.c',
+        'Tests/stubs/time_rtc.c','Tests/stubs/microSD_utils.c','Tests/stubs/fatfs_stub.c','-o','Tests/data_logger_time_runner'
+    ]
+    subprocess.check_call(compile_cmd)
+    return subprocess.run(['Tests/data_logger_time_runner'], capture_output=True, text=True)
+
+def test_time_boundaries():
+    res = build_and_run()
+    assert res.returncode == 0, res.stdout+res.stderr
+    assert 'PASS' in res.stdout


### PR DESCRIPTION
## Summary
- define new temporal averaging structures and macros
- implement time-synced window handling in `data_logger`
- add tests simulating RTC progression
- document RTC-based averaging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c041c5cc832dadc4bcfdd0be034f