### PR TITLE
Fix duplicate function definition

### DIFF
--- a/APIs/Src/data_logger.c
+++ b/APIs/Src/data_logger.c
@@ -117,16 +117,10 @@ static void buffer_circular_agregar(BufferCircular * buffer, const MedicionMP * 
     memcpy(&buffer->datos[indice], medicion, sizeof(MedicionMP));
 }
 
-static int seconds_since_midnight(const ds3231_time_t * t) {
-    return t->hour * 3600 + t->min * 60 + t->sec;
-}
 
-static int time_diff_seconds(const ds3231_time_t * start, const ds3231_time_t * end) {
-    int diff = seconds_since_midnight(end) - seconds_since_midnight(start);
-    if (diff < 0)
-        diff += 24 * 3600;
-    return diff;
-}
+
+static unsigned int time_diff_seconds(const ds3231_time_t * start,
+                                      const ds3231_time_t * end);
 
 static bool is_10min_boundary(const ds3231_time_t * dt) {
     return time_diff_seconds(&current_window.start_time, dt) >= 10 * 60;


### PR DESCRIPTION
## Summary
- clean up duplicate `time_diff_seconds` in `data_logger.c`
- forward declare `time_diff_seconds`

## Testing
- `make -C Debug -j8` *(fails: No rule to make target '/home/lgomez/STM32Cube/Repository/STM32Cube_FW_F4_V1.27.1/Middlewares/Third_Party/FatFs/src/option/ccsbcs.c', needed by 'Middlewares/FatFs/ccsbcs.o')*

------
https://chatgpt.com/codex/tasks/task_e_6854d81b2e08832dbccd4fd39f86511d