### PR TITLE
Implement PM2.5 10‑minute averaging

### DIFF
--- a/APIs/Inc/pm25_avg10.h
+++ b/APIs/Inc/pm25_avg10.h
@@ -1,0 +1,25 @@
+#ifndef PM25_AVG10_H
+#define PM25_AVG10_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "rtc_ds3231_for_stm32_hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void pm25_avg10_add_sample(float pm25);
+void pm25_avg10_process(void);
+
+extern bool flag_promedio_10min;
+
+#if defined(UNIT_TEST) || defined(UNIT_TESTING)
+uint16_t pm25_avg10_get_count(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PM25_AVG10_H

--- a/APIs/Src/pm25_avg10.c
+++ b/APIs/Src/pm25_avg10.c
@@ -1,0 +1,87 @@
+#include "pm25_avg10.h"
+#include "ParticulateDataAnalyzer.h"
+#include "microSD_utils.h"
+#include "uart.h"
+#ifdef UNIT_TESTING
+#undef UNIT_TESTING
+#include "ff_stub.h"
+#define UNIT_TESTING
+#include <stddef.h>
+#include <stdbool.h>
+float calculateAverage(float data[], int n){return 0.0f;}
+float findMaxValue(float data[], int n){return 0.0f;}
+float findMinValue(float data[], int n){return 0.0f;}
+float calculateStandardDeviation(float data[], int n){return 0.0f;}
+#else
+#include "ff.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+
+#define AVG10_BUFFER_SIZE 60
+
+static float pm25_buffer[AVG10_BUFFER_SIZE];
+static uint16_t pm25_count = 0;
+bool flag_promedio_10min = false;
+static int last_boundary_minute = -1;
+
+void pm25_avg10_add_sample(float pm25){
+    pm25_buffer[pm25_count % AVG10_BUFFER_SIZE] = pm25;
+    if(pm25_count < AVG10_BUFFER_SIZE) pm25_count++;
+}
+
+static void clear_buffer(void){
+    pm25_count = 0;
+}
+
+static void save_avg_csv(const ds3231_time_t *dt, float mean, uint16_t count,
+                         float min, float max, float std){
+    char dir[32];
+    snprintf(dir, sizeof(dir), "/%04d/%02d/%02d", dt->year, dt->month, dt->day);
+    f_mkdir(dir);
+
+    char path[64];
+    snprintf(path, sizeof(path), "%s/AVG10.csv", dir);
+
+    char ts[32];
+    snprintf(ts, sizeof(ts), "%04d-%02d-%02d %02d:%02d:%02d", dt->year, dt->month,
+             dt->day, dt->hour, dt->min, dt->sec);
+
+    char line[128];
+    snprintf(line, sizeof(line), "%s,%.2f,%u,%.2f,%.2f,%.2f\n", ts, mean, count,
+             min, max, std);
+    microSD_appendLineAbsolute(path, line);
+}
+
+void pm25_avg10_process(void){
+    ds3231_time_t dt;
+    if(!ds3231_get_datetime(&dt)) return;
+
+    if(dt.min % 10 == 0 && dt.min != last_boundary_minute){
+        flag_promedio_10min = true;
+        last_boundary_minute = dt.min;
+    }
+
+    if(flag_promedio_10min){
+        uint16_t count = pm25_count;
+        float mean = calculateAverage(pm25_buffer, count);
+        float min = findMinValue(pm25_buffer, count);
+        float max = findMaxValue(pm25_buffer, count);
+        float std = calculateStandardDeviation(pm25_buffer, count);
+
+        char ts[32];
+        snprintf(ts, sizeof(ts), "%04d-%02d-%02d %02d:%02d:%02d", dt.year, dt.month,
+                 dt.day, dt.hour, dt.min, dt.sec);
+        uart_print("%s,%.2f,%u,%.2f,%.2f,%.2f\r\n", ts, mean, count, min, max, std);
+
+        save_avg_csv(&dt, mean, count, min, max, std);
+        clear_buffer();
+        flag_promedio_10min = false;
+    }
+}
+
+#if defined(UNIT_TEST) || defined(UNIT_TESTING)
+uint16_t pm25_avg10_get_count(void){
+    return pm25_count;
+}
+#endif

--- a/Tests/avg10_sync_runner.c
+++ b/Tests/avg10_sync_runner.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#define UNIT_TESTING
+#include "stubs/fatfs_stub.h"
+#include "stubs/ff_stub.h"
+#include "stubs/fatfs.h"
+#include "stubs/fatfs_sd.h"
+#include "stubs/microSD_stub.h"
+#include "stubs/microSD_utils.h"
+#include "stubs/rtc.h"
+#include "stubs/time_rtc.h"
+#include "stubs/uart.h"
+#include "stubs/rtc_ds3231_for_stm32_hal.h"
+#include "stubs/ParticulateDataAnalyzer.h"
+#include "stubs/mp_sensors_info.h"
+#include "stubs/main.h"
+#include "stubs/usart.h"
+#include "../APIs/Src/pm25_avg10.c"
+
+int main(void){
+    stub_set_time(15,8,0);
+    for(int i=0;i<12;i++){ // two minutes of samples every 10s
+        pm25_avg10_add_sample(10.0f);
+        stub_advance_seconds(10);
+        pm25_avg10_process();
+    }
+    // advance to 15:10 exact
+    stub_set_time(15,10,0);
+    pm25_avg10_process();
+
+    if(pm25_avg10_get_count()==0 && !flag_promedio_10min){
+        printf("PASS\n");
+        return 0;
+    }else{
+        printf("FAIL count=%u flag=%d\n", pm25_avg10_get_count(), flag_promedio_10min);
+        return 1;
+    }
+}

--- a/Tests/test_avg10_sync.py
+++ b/Tests/test_avg10_sync.py
@@ -1,0 +1,16 @@
+import subprocess
+
+def build_and_run():
+    compile_cmd = [
+        'gcc','-I','Tests/stubs','-I','APIs/Inc',
+        'Tests/avg10_sync_runner.c',
+        'Tests/stubs/time_rtc.c','Tests/stubs/microSD_utils.c','Tests/stubs/fatfs_stub.c',
+        '-o','Tests/avg10_sync_runner'
+    ]
+    subprocess.check_call(compile_cmd)
+    return subprocess.run(['Tests/avg10_sync_runner'], capture_output=True, text=True)
+
+def test_avg10_flag():
+    res = build_and_run()
+    assert res.returncode == 0, res.stdout+res.stderr
+    assert 'PASS' in res.stdout


### PR DESCRIPTION
## Summary
- add `pm25_avg10` module for RTC-synchronised 10‑minute averages
- expose simple API and flag
- unit test for the new averaging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c27b6a7c832da475c61995f5efe1