### PR TITLE
Improve FatFS error docs

### DIFF
--- a/APIs/Inc/microSD_utils.h
+++ b/APIs/Inc/microSD_utils.h
@@ -56,6 +56,14 @@ extern "C" {
  */
 bool microSD_appendLineAbsolute(const char * filepath, const char * line);
 
+/**
+ * @brief Imprime un mensaje descriptivo según el código de error de FatFS.
+ *
+ * Esta función traduce el código de error devuelto por FatFS a un texto
+ * legible y lo envía por la interfaz UART de depuración.
+ *
+ * @param res Código de error retornado por una función FatFS.
+ */
 void print_fatfs_error(FRESULT res);
 
 /* === End of documentation ==================================================================== */

--- a/APIs/Src/microSD_utils.c
+++ b/APIs/Src/microSD_utils.c
@@ -93,6 +93,14 @@ bool microSD_appendLineAbsolute(const char * filepath, const char * line) {
     return (res == FR_OK && bw == strlen(line));
 }
 
+/**
+ * @brief Imprime un mensaje descriptivo del código de error de FatFS.
+ *
+ * Se utiliza para depurar fallas relacionadas con la biblioteca FatFS.
+ * Cada código se traduce a una cadena que se envía por UART.
+ *
+ * @param res Código de error proporcionado por una función FatFS.
+ */
 void print_fatfs_error(FRESULT res) {
     char msg[64];
     snprintf(msg, sizeof(msg), "f_mount() error code: %d\r\n", res);


### PR DESCRIPTION
## Summary
- document `print_fatfs_error` with a full Doxygen block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685625b79dbc832d8e1830018d0f20c1